### PR TITLE
Remote RSN case is preserved in remote submit and now record clan broadcasts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenCentral()
 }
 
-def runeLiteVersion = '1.7.18'
+def runeLiteVersion = '1.8.14'
 
 dependencies {
     implementation group: 'net.jodah', name: 'failsafe', version: '2.4.0'

--- a/src/main/java/fking/work/chatlogger/ChatEntry.java
+++ b/src/main/java/fking/work/chatlogger/ChatEntry.java
@@ -27,7 +27,7 @@ public class ChatEntry {
     }
 
     public static ChatEntry from(long messageId, ChatType chatType, String chatName, ChatMessage chatMessage) {
-		String sender = chatMessage.getName().isEmpty() ? chatName : Text.removeFormattingTags(chatMessage.getName());
+        String sender = chatMessage.getName().isEmpty() ? chatName : Text.removeFormattingTags(chatMessage.getName());
         return new ChatEntry(messageId, chatType, Text.standardize(chatName), sender, chatMessage.getMessage());
     }
 

--- a/src/main/java/fking/work/chatlogger/ChatEntry.java
+++ b/src/main/java/fking/work/chatlogger/ChatEntry.java
@@ -27,7 +27,8 @@ public class ChatEntry {
     }
 
     public static ChatEntry from(long messageId, ChatType chatType, String chatName, ChatMessage chatMessage) {
-        return new ChatEntry(messageId, chatType, Text.standardize(chatName), Text.standardize(chatMessage.getName()), chatMessage.getMessage());
+		String sender = chatMessage.getName().isEmpty() ? chatName : Text.removeFormattingTags(chatMessage.getName());
+        return new ChatEntry(messageId, chatType, Text.standardize(chatName), sender, chatMessage.getMessage());
     }
 
     public enum ChatType {

--- a/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
+++ b/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
@@ -110,12 +110,22 @@ public class ChatLoggerPlugin extends Plugin {
                 break;
             case CLAN_CHAT:
             case CLAN_GUEST_CHAT:
+			case CLAN_MESSAGE:
+				if(event.getMessage().contains("To talk in your clan's channel")){
+					return;
+				}
+
                 if (config.logClanChat()) {
-                    clanChatLogger.info("{}: {}", event.getName(), event.getMessage());
+					if(event.getType() == ChatMessageType.CLAN_MESSAGE){
+						clanChatLogger.info("{}",event.getMessage());
+					}
+                    else{
+						clanChatLogger.info("{}: {}", event.getName(), event.getMessage());
+					}
                 }
 
                 if (config.remoteSubmitLogClanChat() && remoteSubmitter != null) {
-                    ClanChannel clanChannel = event.getType() == ChatMessageType.CLAN_CHAT ? client.getClanChannel() : client.getGuestClanChannel();
+                    ClanChannel clanChannel = event.getType() == ChatMessageType.CLAN_CHAT || event.getType() == ChatMessageType.CLAN_MESSAGE ? client.getClanChannel() : client.getGuestClanChannel();
 
                     if (clanChannel == null) {
                         return;

--- a/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
+++ b/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
@@ -111,12 +111,8 @@ public class ChatLoggerPlugin extends Plugin {
             case CLAN_CHAT:
             case CLAN_GUEST_CHAT:
             case CLAN_MESSAGE:
-                if(event.getMessage().contains("To talk in your clan's channel")){
-                    return;
-                }
-
                 if (config.logClanChat()) {
-                    if(event.getType() == ChatMessageType.CLAN_MESSAGE){
+                    if(event.getType() == ChatMessageType.CLAN_MESSAGE) {
                         clanChatLogger.info("{}",event.getMessage());
                     }
                     else{

--- a/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
+++ b/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
@@ -112,10 +112,9 @@ public class ChatLoggerPlugin extends Plugin {
             case CLAN_GUEST_CHAT:
             case CLAN_MESSAGE:
                 if (config.logClanChat()) {
-                    if(event.getType() == ChatMessageType.CLAN_MESSAGE) {
+                    if (event.getType() == ChatMessageType.CLAN_MESSAGE) {
                         clanChatLogger.info("{}",event.getMessage());
-                    }
-                    else{
+                    } else {
                         clanChatLogger.info("{}: {}", event.getName(), event.getMessage());
                     }
                 }

--- a/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
+++ b/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
@@ -110,18 +110,18 @@ public class ChatLoggerPlugin extends Plugin {
                 break;
             case CLAN_CHAT:
             case CLAN_GUEST_CHAT:
-			case CLAN_MESSAGE:
-				if(event.getMessage().contains("To talk in your clan's channel")){
-					return;
-				}
+            case CLAN_MESSAGE:
+                if(event.getMessage().contains("To talk in your clan's channel")){
+                    return;
+                }
 
                 if (config.logClanChat()) {
-					if(event.getType() == ChatMessageType.CLAN_MESSAGE){
-						clanChatLogger.info("{}",event.getMessage());
-					}
+                    if(event.getType() == ChatMessageType.CLAN_MESSAGE){
+                        clanChatLogger.info("{}",event.getMessage());
+                    }
                     else{
-						clanChatLogger.info("{}: {}", event.getName(), event.getMessage());
-					}
+                        clanChatLogger.info("{}: {}", event.getName(), event.getMessage());
+                    }
                 }
 
                 if (config.remoteSubmitLogClanChat() && remoteSubmitter != null) {


### PR DESCRIPTION
I resolved #11 and added clan broadcast messages such as drops, joined the clan, etc., to be logged. I decided it may be best to keep the sender filled with something for the remote submission. So I set it to the clan name, figured it may break fewer things for developers who use it. 