### PR TITLE
Revert "Fix issue where clan messages appear in private. (#21)"

### DIFF
--- a/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
+++ b/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
@@ -169,7 +169,6 @@ public class ChatLoggerPlugin extends Plugin {
                     String chatName = clanChannel.getName();
                     submitToRemote(chatName, event, clanChannelMemberRank(event.getName(), chatName));
                 }
-                break;
             case PRIVATECHAT:
             case MODPRIVATECHAT:
             case PRIVATECHATOUT:


### PR DESCRIPTION
This commit breaks remote submission of clan broadcasts, reverting it fixes it.

This reverts commit 3715b23f96199c104db7f6200a63885f4b1d1a50.