### PR TITLE
Solved the clan broadcast  issue

### DIFF
--- a/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
+++ b/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
@@ -167,7 +167,8 @@ public class ChatLoggerPlugin extends Plugin {
                         return;
                     }
                     String chatName = clanChannel.getName();
-                    submitToRemote(chatName, event, clanChannelMemberRank(event.getName(), chatName));
+                    int senderRank = event.getType() == ChatMessageType.CLAN_MESSAGE ? CHANNEL_UNRANKED : clanChannelMemberRank(event.getName(), chatName);
+                    submitToRemote(chatName, event, senderRank);
                 }
                 break;
             case PRIVATECHAT:


### PR DESCRIPTION
Solves #23 Appears to been an issue with trying to get a clan channel rank from the clan name. Line 109 would throw a `NullPointerException` ,full log below. Not really sure what caused it. Last message i had was late 12/9, but the issue said they had some up to 12/12. Was clan issues on 12/10 so Jagex may of pushed a patch that changed the way `findMember` worked.
```
2022-12-27 17:07:11 [Client] DEBUG client-patch - Chat message type CLAN_MESSAGE: Some RSN received a drop: Dragon boots (101,546 coins).
2022-12-27 17:07:20 [Client] WARN  n.runelite.client.eventbus.EventBus - Uncaught exception in event subscriber
java.lang.NullPointerException: null
	at java.base/java.lang.String.compareTo(String.java:1196)
	at fn.findMember(fn.java:14858)
	at fking.work.chatlogger.ChatLoggerPlugin.clanChannelMemberRank(ChatLoggerPlugin.java:109)
	at fking.work.chatlogger.ChatLoggerPlugin.onChatMessage(ChatLoggerPlugin.java:170)
	at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:70)
	at net.runelite.client.eventbus.EventBus.post(EventBus.java:223)
	at net.runelite.client.callback.Hooks.post(Hooks.java:190)
	at nq.e(nq.java:62943)
	at client.il(client.java:7438)
	at client.gg(client.java:2813)
	at client.an(client.java:1119)
	at an.xi(an.java:390)
	at an.run(an.java:369)
	at java.base/java.lang.Thread.run(Thread.java:829)

```