### PR TITLE
Changed name recording formatting 

### DIFF
--- a/src/main/java/fking/work/chatlogger/ChatEntry.java
+++ b/src/main/java/fking/work/chatlogger/ChatEntry.java
@@ -29,7 +29,7 @@ public class ChatEntry {
     }
 
     public static ChatEntry from(long messageId, ChatType chatType, String chatName, int rank, ChatMessage chatMessage) {
-        String sender = chatMessage.getName().isEmpty() ? chatName : Text.removeFormattingTags(chatMessage.getName());
+        String sender = chatMessage.getName().isEmpty() ? chatName : Text.removeFormattingTags(Text.toJagexName(chatMessage.getName()));
         return new ChatEntry(messageId, chatType, Text.standardize(chatName), sender, rank, chatMessage.getMessage());
     }
 

--- a/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
+++ b/src/main/java/fking/work/chatlogger/ChatLoggerPlugin.java
@@ -136,7 +136,7 @@ public class ChatLoggerPlugin extends Plugin {
 
             case FRIENDSCHAT:
                 if (config.logFriendsChat()) {
-                    friendsChatLogger.info("[{}] {}: {}", event.getSender(), event.getName(), event.getMessage());
+                    friendsChatLogger.info("[{}] {}: {}", event.getSender(),nameFormatting(event.getName()), event.getMessage());
                 }
 
                 if (config.remoteSubmitLogFriendsChat() && remoteSubmitter != null) {
@@ -156,7 +156,7 @@ public class ChatLoggerPlugin extends Plugin {
                     if (event.getType() == ChatMessageType.CLAN_MESSAGE) {
                         clanChatLogger.info("{}", event.getMessage());
                     } else {
-                        clanChatLogger.info("{}: {}", event.getName(), event.getMessage());
+                        clanChatLogger.info("{}: {}", nameFormatting(event.getName()), event.getMessage());
                     }
                 }
 
@@ -175,13 +175,13 @@ public class ChatLoggerPlugin extends Plugin {
             case PRIVATECHATOUT:
                 if (config.logPrivateChat()) {
                     String predicate = event.getType() == ChatMessageType.PRIVATECHATOUT ? "To" : "From";
-                    privateChatLogger.info("{} {}: {}", predicate, event.getName(), event.getMessage());
+                    privateChatLogger.info("{} {}: {}", predicate, nameFormatting(event.getName()), event.getMessage());
                 }
                 break;
             case MODCHAT:
             case PUBLICCHAT:
                 if (config.logPublicChat()) {
-                    publicChatLogger.info("{}: {}", event.getName(), event.getMessage());
+                    publicChatLogger.info("{}: {}", nameFormatting(event.getName()), event.getMessage());
                 }
                 break;
         }
@@ -225,5 +225,9 @@ public class ChatLoggerPlugin extends Plugin {
         logger.addAppender(appender);
 
         return logger;
+    }
+
+    private String nameFormatting(String name){
+        return Text.removeFormattingTags(Text.toJagexName(name));
     }
 }


### PR DESCRIPTION
I had a runaround with this one.  Resolves #22 .
* `Text.sanitize` would remove all formatting but still missed NBSP. Not sure why because it looks like it should remove, but it did not.
* `Text.toJagexName` get's NBSP but leaves the `<img>` tags. Does change `_` to a `space` but can look up on hiscores with a space instead of an underscore, and it works. So that would be fine unless we are worried about breaking anything that does an exact name search on the web request.
* Did notice that clan broadcasts still display the name with NBSP. But felt like that was a whole other can of worms to look at how we should format message content.


I ended up with the result I did because it covered both edge cases. 
